### PR TITLE
mkcert chaining

### DIFF
--- a/Certificate.go
+++ b/Certificate.go
@@ -30,6 +30,16 @@ type Certificate struct {
 	Declarations Chain
 }
 
+func CertificateFromFile(fn string) (*Certificate, error) {
+	var cert Certificate
+	err := fromFile(fn, &cert)
+	return &cert, err
+}
+
+func (c *Certificate) ToFile(fn string) error {
+	return toFile(c, fn)
+}
+
 func NewTestament(subjectID string, subjectkey PublicKey) *Testament {
 
 	x := new(Testament)

--- a/Credentials.go
+++ b/Credentials.go
@@ -1,10 +1,5 @@
 package hippo
 
-import (
-	"encoding/json"
-	"io/ioutil"
-)
-
 // Verifier wraps a public key and can verify data.
 type Verifier interface {
 	PublicKey() PublicKey
@@ -38,7 +33,7 @@ type PublicKey struct {
 }
 
 func (k PublicKey) ToFile(fn string) error {
-	return keyToFile(k, fn)
+	return toFile(k, fn)
 }
 
 // PrivateKey is a structure for importing and exporting private
@@ -53,17 +48,18 @@ type PrivateKey struct {
 }
 
 func (k PrivateKey) ToFile(fn string) error {
-	return keyToFile(k, fn)
+	return toFile(k, fn)
 }
 
 // Signatures are padded Base64 standard encoded strings.
 type Signature string
 
+
 // PublicKeyFromFile reads the entirety of the given file and attempts
 // to parse it into a PublicKey.
 func PublicKeyFromFile(fn string) (*PublicKey, error) {
 	var key PublicKey
-	err := keyFromFile(fn, &key)
+	err := fromFile(fn, &key)
 	return &key, err
 }
 
@@ -71,24 +67,6 @@ func PublicKeyFromFile(fn string) (*PublicKey, error) {
 // attempts to parse it into a PrivateKey.
 func PrivateKeyFromFile(fn string) (*PrivateKey, error) {
 	var key PrivateKey
-	err := keyFromFile(fn, &key)
+	err := fromFile(fn, &key)
 	return &key, err
-}
-
-func keyFromFile(fn string, key interface{}) error {
-	buf, err := ioutil.ReadFile(fn)
-	if err != nil {
-		return err
-	}
-
-	return json.Unmarshal(buf, key)
-}
-
-func keyToFile(key interface{}, fn string) error {
-	buf, err := json.Marshal(key)
-	if err != nil {
-		return err
-	}
-
-	return ioutil.WriteFile(fn, buf, 0644)
 }

--- a/cmd/mkcert/main.go
+++ b/cmd/mkcert/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"strings"
 
 	"github.com/BellerophonMobile/hippo"
@@ -14,7 +13,8 @@ import (
 type claims map[string]interface{}
 
 func (c claims) String() string {
-	return "asdf"
+	bytes, _ := json.Marshal(c)
+	return string(bytes)
 }
 
 func (c claims) Set(flag string) error {
@@ -128,19 +128,10 @@ func sign(id string, testament *hippo.Testament, signer hippo.Credentials) *hipp
 }
 
 func writeCert(cert *hippo.Certificate, filename string) {
-
 	task := logberry.Main.Task("Write certificate")
-
-	bytes, err := json.Marshal(cert)
-	if err != nil {
-		task.DieFatal("Failed to marshal certificate", err)
-	}
-
-	err = ioutil.WriteFile(filename, bytes, 0644)
+	err := cert.ToFile(filename)
 	if err != nil {
 		task.Fatal(err)
 	}
-
 	task.Success()
-
 }

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,24 @@
+package hippo
+
+import (
+	"encoding/json"
+	"io/ioutil"
+)
+
+func fromFile(fn string, key interface{}) error {
+	buf, err := ioutil.ReadFile(fn)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(buf, key)
+}
+
+func toFile(key interface{}, fn string) error {
+	buf, err := json.Marshal(key)
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(fn, buf, 0644)
+}


### PR DESCRIPTION
Add `-chain` option to mkcert.

Also, attempt to parse claim values as booleans or numbers.  Strings now need to be quoted.